### PR TITLE
Add openai & reportlab to backend requirements

### DIFF
--- a/goscenic-backend/requirements.txt
+++ b/goscenic-backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 requests
 python-dotenv
 
+openai
+reportlab


### PR DESCRIPTION
## Summary
- include `openai` and `reportlab` in goscenic-backend dependencies

## Testing
- `nl -ba goscenic-backend/requirements.txt`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c6b1b0edc8325830f373cec28ab07