### PR TITLE
Add mobile and web scaffolds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ venv/
 .terraform.lock.hcl
 goscenic-backend/itinerary.json
 goscenic-backend/itinerary.json
+# Next.js build output
+web/.next/

--- a/README.md
+++ b/README.md
@@ -122,4 +122,14 @@ Scalability: Built on AWS, ensuring high availability and performance even with 
 
 Conclusion
 
-GoScenic is an all-in-one road trip planning solution, integrating AI-driven route optimization, cost estimation, and travel assistance. With an intuitive interface and a robust backend, GoScenic is poised to redefine the way users plan and experience road trips. The application offers a unique blend of personalization, real-time insights, and offline accessibility, making it a must-have tool for adventure seekers and travel enthusiasts.# GoScenic
+GoScenic is an all-in-one road trip planning solution, integrating AI-driven route optimization, cost estimation, and travel assistance. With an intuitive interface and a robust backend, GoScenic is poised to redefine the way users plan and experience road trips. The application offers a unique blend of personalization, real-time insights, and offline accessibility, making it a must-have tool for adventure seekers and travel enthusiasts.
+
+Development Setup
+-----------------
+
+The repository now includes example front-end projects for mobile and web clients inspired by the Roadtrippers experience.
+
+- **`mobile/`** – React Native project using Expo for iOS and Android.
+- **`web/`** – Next.js project for desktop browsers.
+
+To start either project, navigate into the directory and run `npm install` followed by `npm start` (or `npm run dev` for the web app).

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Welcome to GoScenic! Start planning your road trip.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,12 @@
+# GoScenic Mobile
+
+This directory contains a minimal React Native skeleton for the GoScenic mobile application for both iOS and Android. The structure is intentionally lightweight so developers can build upon it. Features are inspired by Roadtrippers, focusing on scenic route planning and trip management.
+
+To get started, install the dependencies and run the Expo development server:
+
+```bash
+npm install
+npm start
+```
+
+This uses [Expo](https://expo.dev) for quick prototyping and testing across mobile devices. The app simply renders a placeholder screen which you can replace with real functionality.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "goscenic-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0"
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,12 @@
+# GoScenic Web
+
+This directory contains a minimal Next.js setup for the desktop web version of GoScenic. It provides a baseline structure similar to Roadtrippers for building scenic route and itinerary features.
+
+To begin development:
+
+```bash
+npm install
+npm run dev
+```
+
+The example page at `/pages/index.js` is a placeholder that you can expand with real components.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "goscenic-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/web/pages/index.js
+++ b/web/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>GoScenic Web</h1>
+      <p>Plan scenic road trips right from your desktop.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `.next` to `.gitignore`
- add placeholder React Native app in `mobile`
- add placeholder Next.js app in `web`
- document development setup in README

## Testing
- `python3 -m py_compile goscenic-backend/main.py`
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c83b048508325abb2c4141d8c528a