### PR TITLE
Fix .gitignore duplicate entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ venv/
 *.tfstate.backup
 .terraform.lock.hcl
 goscenic-backend/itinerary.json
-goscenic-backend/itinerary.json
 # Next.js build output
 web/.next/


### PR DESCRIPTION
## Summary
- deduplicate goscenic-backend/itinerary.json entry in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c868a53e8832589993bc843bdd56a