### PR TITLE
Fix .gitignore for nested repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ goscenic-backend/itinerary.json
 # Next.js build output
 web/.next/
 GoScenic.git/
+GoScenic.git/


### PR DESCRIPTION
## Summary
- add `GoScenic.git/` to `.gitignore`

## Testing
- `npm test` *(fails: no `package.json` found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8cf42e808325b68b59b628f44d53