### PR TITLE
Add backend setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ The repository now includes example front-end projects for mobile and web client
 
 To start either project, navigate into the directory and run `npm install` followed by `npm start` (or `npm run dev` for the web app).
 
+For the API backend located in **`goscenic-backend/`**, install the Python dependencies and start the server with:
+
+```bash
+python3 -m pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
 Terraform CLI
 -------------
 


### PR DESCRIPTION
## Summary
- document how to install Python requirements
- show how to run the FastAPI server with `uvicorn`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8cf6d2f4832582d08d798ccde34b