### PR TITLE
Remove duplicate .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ goscenic-backend/itinerary.json
 # Next.js build output
 web/.next/
 GoScenic.git/
-GoScenic.git/


### PR DESCRIPTION
## Summary
- clean up `.gitignore` by keeping only one `GoScenic.git/` entry

## Testing
- `sort .gitignore | uniq -d`

------
https://chatgpt.com/codex/tasks/task_e_686dda49bbf88325be1301cb5e631f4e