### PR TITLE
Add .dockerignore for backend image

### DIFF
--- a/goscenic-backend/.dockerignore
+++ b/goscenic-backend/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore large directories and unwanted files
+**
+
+# Allow backend app files
+!main.py
+!requirements.txt
+!Dockerfile
+
+# Additional directories to ignore if context is repository root
+.git/
+mobile/
+web/
+terraform/


### PR DESCRIPTION
## Summary
- add `.dockerignore` to the backend project
- limit Docker context to the Python app files

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -t goscenic-backend-test ./goscenic-backend` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686de81497cc8325ac66731261b9a48a