### PR TITLE
Add S3 backend block for state management

### DIFF
--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -42,3 +42,14 @@ resource "aws_dynamodb_table" "terraform_locks" {
     Name = "terraform-lock"
   }
 }
+# Configure the backend for storing Terraform state
+terraform {
+  backend "s3" {
+    bucket         = "goscenic-terraform-state"
+    key            = "infra/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "goscenic-tf-lock"
+    encrypt        = true
+  }
+}
+


### PR DESCRIPTION
## Summary
- configure Terraform backend in `terraform/state.tf`

## Testing
- `terraform fmt -check`

------
https://chatgpt.com/codex/tasks/task_e_686df37527848325b73f29463dd7aa9e