### PR TITLE
Add itinerary planning endpoint

### DIFF
--- a/goscenic-backend/main.py
+++ b/goscenic-backend/main.py
@@ -10,6 +10,7 @@ import openai
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.decorator import cache
+from routes import itinerary
 
 load_dotenv()
 
@@ -23,6 +24,8 @@ client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
 app = FastAPI()
 
+# Register additional routers
+app.include_router(itinerary.router, prefix="/api")
 
 @app.on_event("startup")
 async def startup_event() -> None:

--- a/goscenic-backend/models/itinerary.py
+++ b/goscenic-backend/models/itinerary.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class ItineraryRequest(BaseModel):
+    start_location: str
+    end_location: str
+    total_budget: float
+    num_days: int
+    num_people: int
+    car_mpg: float
+    car_year: int
+    car_model: str
+    lodging_type: Literal['camping', 'motel', 'hotel']
+    food_pref: Literal['veg', 'non-veg', 'vegan', 'any']

--- a/goscenic-backend/routes/itinerary.py
+++ b/goscenic-backend/routes/itinerary.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from models.itinerary import ItineraryRequest
+from services.planner import generate_itinerary
+
+router = APIRouter()
+
+@router.post("/itinerary")
+async def plan_trip(req: ItineraryRequest):
+    return await generate_itinerary(req)

--- a/goscenic-backend/services/planner.py
+++ b/goscenic-backend/services/planner.py
@@ -1,0 +1,29 @@
+from models.itinerary import ItineraryRequest
+
+async def generate_itinerary(req: ItineraryRequest):
+    # Placeholder for real APIs (Google, GasBuddy, Yelp, etc.)
+    route = {
+        "miles": 2200,
+        "stops": ["Columbus, OH", "Denver, CO", "Moab, UT"]
+    }
+
+    gas_price = 3.6  # Static for now
+    total_gas_cost = (route["miles"] / req.car_mpg) * gas_price
+
+    lodging_per_night = {
+        "camping": 30, "motel": 80, "hotel": 150
+    }[req.lodging_type]
+
+    lodging_total = lodging_per_night * req.num_days
+    food_total = 40 * req.num_people * req.num_days
+
+    total_estimated = total_gas_cost + lodging_total + food_total
+
+    return {
+        "route": route,
+        "gas_cost": round(total_gas_cost, 2),
+        "lodging_total": lodging_total,
+        "food_total": food_total,
+        "total_estimated": round(total_estimated, 2),
+        "budget_remaining": round(req.total_budget - total_estimated, 2)
+    }


### PR DESCRIPTION
## Summary
- support itinerary planning endpoint `/api/itinerary`
- implement planner service and request model
- register itinerary route in API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eed6e296483258a3733cc828fef87